### PR TITLE
Corrected link for Video 

### DIFF
--- a/source/visualization/index.ipynb
+++ b/source/visualization/index.ipynb
@@ -58,7 +58,7 @@
     "|[Radar](radar.ipynb)|Radar|\"radar\"|\n",
     "|[Radviz](radviz.ipynb)|Radviz|\"radviz\"|\n",
     "|[Star Coordinates](star.ipynb)|StarCoordinate|\"star\"|\n",
-    "|[Video](star.ipynb)|Video|-|\n"
+    "|[Video](video.ipynb)|Video|-|\n"
    ]
   },
   {


### PR DESCRIPTION
Clicking on Video on this [page](https://pymoo.org/visualization/index.html) earlier redirected to star. That is fixed now with this PR.