### PR TITLE
fix selection operator example

### DIFF
--- a/source/operators/selection.ipynb
+++ b/source/operators/selection.ipynb
@@ -118,21 +118,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
-      "Compiled modules for significant speedup can not be used!\n",
-      "https://pymoo.org/installation.html#installation\n",
-      "\n",
-      "To disable this warning:\n",
-      "from pymoo.config import Config\n",
-      "Config.show_compile_hint = False\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[2.44446330e-05 7.11970593e-05]\n"
+      "[0.00058466 0.00030566]\n"
      ]
     }
    ],
@@ -150,7 +136,7 @@
     "    \n",
     "    # the result this function returns\n",
     "    import numpy as np\n",
-    "    S = np.full(n_tournaments, -1, dtype=np.int)\n",
+    "    S = np.full(n_tournaments, -1, dtype=int)\n",
     "\n",
     "    # now do all the tournaments\n",
     "    for i in range(n_tournaments):\n",
@@ -167,7 +153,7 @@
     "    return S\n",
     "    \n",
     "\n",
-    "selection = get_selection('tournament', {'pressure' : 2, 'func_comp' : binary_tournament})\n",
+    "selection = get_selection('tournament', pressure=2, func_comp=binary_tournament)\n",
     "\n",
     "\n",
     "\n",
@@ -179,8 +165,9 @@
     "res = minimize(\n",
     "    get_problem(\"rastrigin\"), \n",
     "    get_algorithm(\"ga\", \n",
-    "                           pop_size=100, \n",
-    "                           eliminate_duplicates=True),\n",
+    "                  pop_size=100,\n",
+    "                  selection=selection, \n",
+    "                  eliminate_duplicates=True),\n",
     "    termination=('n_gen', 50), \n",
     "    verbose=False)\n",
     "\n",

--- a/source/operators/selection.ipynb
+++ b/source/operators/selection.ipynb
@@ -143,7 +143,7 @@
     "        a, b = P[i]\n",
     "        \n",
     "        # if the first individiual is better, choose it\n",
-    "        if pop[a].F < pop[a].F:\n",
+    "        if pop[a].F < pop[b].F:\n",
     "            S[i] = a\n",
     "            \n",
     "        # otherwise take the other individual\n",


### PR DESCRIPTION
in [Tournament Selection](https://pymoo.org/operators/selection.html#Tournament-Selection-(%E2%80%98tournament%E2%80%99)) example, custom selection was never used by get_algorithm() and after adding that there was a TypeError: "dict object is not callable" so changed the argument of get_selection() function to keyword arguments instead of a dict like other operator examples. 